### PR TITLE
Full rewrite of collective.prometheus

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,22 +2,36 @@
 Prometheus Plone Integration
 ============================
 
-This package publishes Plone statistics in a format that can be consumed by Prometheus_.
+This package publishes Plone/Zope statistics in a format that can be
+consumed by Prometheus_. It is built on top of the official
+``prometheus_client`` library.
 
 It was largely based on ``munin.zope``. See https://pypi.org/project/munin.zope/
 
-It provides the following data:
+Metrics
+-------
 
-  * The number of running Zope ZServer threads (with the `zserver` extra)
-  * The number of Zope ZServer threads not in use (with the `zserver` extra)
-  * The number of objects in the Zope database
-  * Memory used by the Zope cache
-  * The number of objects that can be stored in the Zope cache
-  * ZODB load count
-  * ZODB store count
-  * ZODB connections
-  * Active Zope Objects
-  * Total Zope Objects
+============================================== ======== =================
+Name                                           Type     Labels
+============================================== ======== =================
+zope_total_threads                             gauge    —
+zope_free_threads                              gauge    —
+zope_busy_threads                              gauge    —
+zope_request_queue_length                      gauge    —
+zope_total_objects                             gauge    db
+zope_cache_objects                             gauge    db
+zope_cache_size                                gauge    db
+zodb_connections                               gauge    db
+zodb_object_loads_total                        counter  db
+zodb_object_stores_total                       counter  db
+zope_connection_active_objects                 gauge    db, connection
+zope_connection_total_objects                  gauge    db, connection
+============================================== ======== =================
+
+The ``zope_*_threads`` and ``zope_request_queue_length`` gauges are only
+emitted when ZServer is available (install with the ``zserver`` extra).
+Standard ``process_*`` and ``python_*`` metrics from ``prometheus_client``
+are also exposed.
 
 Installation (using Buildout)
 -----------------------------
@@ -27,9 +41,11 @@ Add ``collective.prometheus`` to your instance eggs in ``buildout.cfg``.
 Usage
 -----
 
-Assuming Plone listens on ``localhost:8000``, start your Plone instance and visit http://localhost:8000/@@metrics to see the output and confirm that data is being reported.
+Assuming Plone listens on ``localhost:8000``, start your Plone instance
+and visit http://localhost:8000/@@metrics to confirm output is being
+served.
 
-If so, add a job to your ``scrape_configs`` in ``pometheus.yaml``:
+Add a job to ``scrape_configs`` in ``prometheus.yaml``:
 
 .. code-block:: yaml
 
@@ -37,5 +53,57 @@ If so, add a job to your ``scrape_configs`` in ``pometheus.yaml``:
       metrics_path: '/@@metrics'
       static_configs:
       - targets: ['localhost:8000']
+
+Pass ``?filestorage=*`` to scrape every configured filestorage; pass
+``?filestorage=<name>`` for a single one. The default scrapes ``main``.
+
+Example PromQL
+--------------
+
+.. code-block:: promql
+
+    # Object load rate per database
+    rate(zodb_object_loads_total[5m])
+
+    # ZODB size by database
+    sum by (db) (zope_total_objects)
+
+    # Largest connection cache
+    max by (connection) (zope_connection_active_objects)
+
+    # Worker saturation
+    zope_busy_threads / zope_total_threads
+
+Security
+--------
+
+The ``metrics`` view ships with the default ``zope2.View`` permission so
+that existing anonymous Prometheus scrape jobs keep working after upgrade.
+For production deployments it is recommended to:
+
+* Override the ``metrics`` view permission to ``zope2.ManageServer`` (or a
+  custom permission granted only to a dedicated scrape user) via a ZCML
+  override. Drop the following into your policy package's
+  ``overrides.zcml``:
+
+  .. code-block:: xml
+
+      <configure xmlns:browser="http://namespaces.zope.org/browser">
+        <browser:page
+            for="*"
+            name="metrics"
+            class="collective.prometheus.browser.Prometheus"
+            permission="zope2.ManageServer"
+            />
+      </configure>
+
+* Restrict access to ``/@@metrics`` at the network/reverse-proxy layer.
+
+Upgrading to 2.0
+----------------
+
+Version 2.0 is a breaking rewrite. Metric names, labels, and the wire
+format have all changed. See ``docs/HISTORY.txt`` for the full list of
+changes; downstream Grafana dashboards will need to be updated.
 
 .. _Prometheus: https://prometheus.io/

--- a/README.rst
+++ b/README.rst
@@ -26,17 +26,42 @@ zodb_object_loads_total                        counter  db
 zodb_object_stores_total                       counter  db
 zope_connection_active_objects                 gauge    db, connection
 zope_connection_total_objects                  gauge    db, connection
+plone_version_info                             gauge    plone_version, cmf_version
+plone_catalog_size                             gauge    —
+plone_catalog_index_size                       gauge    index
+plone_content_objects                          gauge    portal_type
+plone_users_total                              gauge    —
+plone_groups_total                             gauge    —
 ============================================== ======== =================
 
 The ``zope_*_threads`` and ``zope_request_queue_length`` gauges are only
 emitted when ZServer is available (install with the ``zserver`` extra).
+The ``plone_*`` metrics are emitted only when ``Products.CMFPlone`` is
+importable (install with the ``plone`` extra, or rely on Plone already
+being present in the instance).
 Standard ``process_*`` and ``python_*`` metrics from ``prometheus_client``
 are also exposed.
+
+Endpoints
+---------
+
+* ``/@@metrics`` — Zope/process/ZODB metrics. Works at the Zope
+  application root and inside any traversable object. Always safe to
+  scrape, even on bare-Zope (non-Plone) deployments.
+* ``/<site_id>/@@metrics`` — adds Plone metrics
+  (``plone_catalog_size``, ``plone_catalog_index_size``,
+  ``plone_content_objects``, ``plone_users_total``,
+  ``plone_groups_total``, ``plone_version_info``). This is the
+  canonical scrape target for a Plone site.
 
 Installation (using Buildout)
 -----------------------------
 
 Add ``collective.prometheus`` to your instance eggs in ``buildout.cfg``.
+
+On a bare-Zope install, only ``zope_*`` and ``zodb_*`` metrics are
+exposed. Install with ``pip install collective.prometheus[plone]`` (or
+add ``Products.CMFPlone`` separately) to enable the ``plone_*`` metrics.
 
 Usage
 -----
@@ -73,6 +98,12 @@ Example PromQL
 
     # Worker saturation
     zope_busy_threads / zope_total_threads
+
+    # Top 10 most common content types
+    topk(10, plone_content_objects)
+
+    # Catalog growth rate (objects/sec) over the last hour
+    deriv(plone_catalog_size[1h])
 
 Security
 --------

--- a/analysis.md
+++ b/analysis.md
@@ -1,0 +1,30 @@
+### What was happening
+`/@@metrics` is published at the **Zope app root**, not inside the Plone site. So `self.context` in the view is the root `Application` object, which has no `portal_catalog` / `acl_users`. `getToolByName(root, 'portal_catalog')` raises `AttributeError: portal_catalog`, and the same thing would happen for `_collect_users`.
+
+The Zope-level metrics (process, ZODB, connections) work because they don't need a Plone site.
+
+### Fix applied
+Patched `_PloneCollector.__init__` in `devel/collective.prometheus/src/collective/prometheus/browser.py` to resolve a usable site context: if the given context has no `portal_catalog`, it scans child items at the app root and picks the first one that does (your `at_plone`). Falls back to original context otherwise.
+
+```python
+def __init__(self, request, context):
+    self._request = request
+    self._context = self._resolve_site(context)
+
+@staticmethod
+def _resolve_site(context):
+    if getToolByName(context, 'portal_catalog', None) is not None:
+        return context
+    try:
+        for _id, obj in context.objectItems():
+            if getToolByName(obj, 'portal_catalog', None) is not None:
+                return obj
+    except Exception:
+        pass
+    return context
+```
+
+### Notes / alternatives to consider
+- **Multi-site case:** if you ever host more than one Plone site in the same Zope, this picks "the first one." A cleaner long-term fix is to either (a) iterate all sites and label metrics with a `site_id`, or (b) require scraping `/<site_id>/@@metrics` and skip Plone collectors at the root.
+- **Permissions:** at the app root the view runs without a Plone site's `unrestrictedTraverse` semantics — make sure whoever scrapes `/` has rights, or move the endpoint to `/at_plone/@@metrics` and just delete the root-resolution hack.
+- The file was copied straight into the running container; on next `compose up --build` it'll be baked in via `COPY . .` since you edited the source on the host.

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -1,3 +1,29 @@
+2.0.0 (UNRELEASED)
+
+  * BREAKING: Adopt prometheus_client for exposition. The metrics endpoint
+    now sets Content-Type and Cache-Control headers and supports
+    OpenMetrics via Accept negotiation.
+  * BREAKING: zodb_load_count / zodb_store_count → zodb_object_loads_total /
+    zodb_object_stores_total (correctly typed as counters; sourced from a
+    monotonic accumulator instead of a 15-second window).
+  * BREAKING: per-database metrics now carry a `db` label instead of
+    `_<dbname>` suffixes.
+  * BREAKING: per-connection metrics use `connection` label instead of
+    `thread`. Fixes a bug where connection 0 produced an unlabeled series
+    that collided with later samples.
+  * BREAKING: zope_cache_memory renamed to zope_cache_objects (it counts
+    objects, not bytes — HELP text was wrong).
+  * Add zope_busy_threads, zope_request_queue_length gauges.
+  * Mount prometheus_client.PROCESS_COLLECTOR and PLATFORM_COLLECTOR.
+  * Drop Python <2.5 threadframe support; use sys._current_frames and
+    __self__ directly.
+  * Each sub-collector is now isolated: one failure no longer blanks the
+    scrape.
+  * NOTE: zodb_object_loads_total and zodb_object_stores_total are
+    process-lifetime accumulators and reset to zero on Zope restart.
+    This is standard Prometheus counter behavior — dashboards must use
+    rate() / increase() rather than reading the raw value.
+
 1.6.1
 
   * Fix metric naming for thread-local metrics

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -1,5 +1,15 @@
 2.0.0 (UNRELEASED)
 
+  * Restrict Plone collectors to IPloneSiteRoot; root scrape
+    (/@@metrics) now returns Zope-only metrics instead of
+    AttributeError tracebacks for portal_catalog / acl_users. The
+    canonical Plone scrape URL is /<site_id>/@@metrics. Add
+    _resolve_site defensive fallback in _PloneCollector.
+  * Add Plone-domain metrics: plone_version_info, plone_catalog_size,
+    plone_catalog_index_size, plone_content_objects, plone_users_total,
+    plone_groups_total. Enabled automatically when CMFPlone is importable;
+    bare-Zope installs are unaffected. New optional ``[plone]`` extra in
+    setup.py.
   * BREAKING: Adopt prometheus_client for exposition. The metrics endpoint
     now sets Content-Type and Cache-Control headers and supports
     OpenMetrics via Accept negotiation.

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,8 @@ setup(
     install_requires=install_requires,
     extras_require={
         'zserver': ['Products.ZServerViews>=0.2'],
-        'test': ['plone.app.testing'],
+        'plone':   ['Products.CMFPlone'],
+        'test':    ['plone.app.testing'],
     },
     entry_points="""
     [z3c.autoinclude.plugin]

--- a/setup.py
+++ b/setup.py
@@ -1,14 +1,14 @@
 from setuptools import setup, find_packages
 from os.path import join
-import sys
 
-version = '1.6.1'
+version = '2.0.0'
 readme = open("README.rst").read()
 history = open(join('docs', 'HISTORY.txt')).read()
 
-install_requires = ['setuptools']
-if sys.version_info < (2, 5):
-    install_requires.append('threadframe')
+install_requires = [
+    'setuptools',
+    'prometheus_client>=0.17',
+]
 
 setup(
     name='collective.prometheus',
@@ -19,7 +19,6 @@ setup(
         'Programming Language :: Python',
         'Framework :: Plone',
         'Framework :: ZODB',
-        'Framework :: Zope2',
         'Intended Audience :: Developers',
         'Intended Audience :: System Administrators',
         'Programming Language :: Python',

--- a/src/collective/prometheus/browser.py
+++ b/src/collective/prometheus/browser.py
@@ -1,162 +1,171 @@
+"""Prometheus exporter for Zope/Plone."""
+
+import logging
 import sys
-from time import time
+import threading
+import time
+
+from prometheus_client import CollectorRegistry, PROCESS_COLLECTOR, PLATFORM_COLLECTOR
+from prometheus_client.core import CounterMetricFamily, GaugeMetricFamily
+from prometheus_client.exposition import choose_encoder
 
 from Products.Five.browser import BrowserView
 from zExceptions import NotFound
 from ZODB.ActivityMonitor import ActivityMonitor
+
 try:
     import ZServer.PubCore
     Z_SERVER = True
 except Exception:
     Z_SERVER = False
 
+logger = logging.getLogger(__name__)
 
-def metric(name, value, metric_type=None, help_text=None, thread=None):
-    HELP_TMPL = '# HELP {0} {1}\n'
-    TYPE_TMPL = '# TYPE {0} {1}\n'
-    output = ''
-    if help_text is not None:
-        output += HELP_TMPL.format(name, help_text)
-    if metric_type is not None:
-        output += TYPE_TMPL.format(name, metric_type)
-    if thread:
-        name = name + '{thread="' + str(thread) + '"}'
-    output += '{0} {1}\n'.format(name, value)
-    return output
+
+# Monotonic ZODB activity totals, keyed by db name. Survives across
+# scrapes for the lifetime of the process; resets on restart (see
+# HISTORY.txt 2.0.0 note). Guarded by `_ACTIVITY_LOCK` because Zope
+# serves /@@metrics on multiple threads.
+_ACTIVITY = {}            # dbname -> {'loads': int, 'stores': int, 'last_end': float}
+_ACTIVITY_LOCK = threading.Lock()
+
+
+def _gauge(name, help_text, labels=()):
+    return GaugeMetricFamily(name, help_text, labels=list(labels))
+
+
+def _counter(name, help_text, labels=()):
+    return CounterMetricFamily(name, help_text, labels=list(labels))
+
+
+class _ZopeCollector(object):
+    """Per-scrape collector. One instance per /@@metrics request.
+
+    Sub-collectors are isolated; one failure won't blank a scrape.
+    """
+
+    def __init__(self, request, context):
+        self._request = request
+        self._context = context
+
+    def _safe(self, name, gen):
+        try:
+            yield from gen()
+        except Exception:
+            logger.exception("collector %s failed", name)
+
+    def collect(self):
+        sub_collectors = (
+            ('zopethreads',     self._collect_threads,     Z_SERVER),
+            ('zopecache',       self._collect_cache,       True),
+            ('zodbactivity',    self._collect_activity,    True),
+            ('zopeconnections', self._collect_connections, True),
+        )
+        for name, fn, enabled in sub_collectors:
+            if enabled:
+                yield from self._safe(name, fn)
+
+    def _getdbs(self):
+        fs = self._request.get('filestorage')
+        db = self._context.unrestrictedTraverse('/Control_Panel/Database')
+        if fs == '*':
+            for n in db.getDatabaseNames():
+                yield db[n], n
+        elif fs:
+            if fs not in db.getDatabaseNames():
+                raise NotFound
+            yield db[fs], fs
+        else:
+            yield db['main'], 'main'
+
+    def _collect_threads(self):
+        total = len(sys._current_frames())
+        handle = getattr(ZServer.PubCore, '_handle', None)
+        lists = ((), (), ())
+        if handle is not None:
+            lists = handle.__self__._lists
+        # See ZRendezvous.__init__: (busy, request_queue, free)
+        busy, queued, free = (len(l) for l in lists)
+        for name, help_text, val in (
+            ('zope_total_threads', 'Number of running Zope threads.', total),
+            ('zope_free_threads', 'Idle Zope worker threads.', free),
+            ('zope_busy_threads', 'Zope worker threads handling a request.', busy),
+            ('zope_request_queue_length', 'Requests waiting for a worker.', queued),
+        ):
+            g = _gauge(name, help_text)
+            g.add_metric([], val)
+            yield g
+
+    def _collect_cache(self):
+        specs = [
+            (_gauge('zope_total_objects', 'Number of objects in the ZODB.', ['db']),
+             lambda db: db.database_size()),
+            (_gauge('zope_cache_objects', 'Objects currently held in the ZODB cache.', ['db']),
+             lambda db: db.cache_length()),
+            (_gauge('zope_cache_size', 'Configured maximum objects per ZODB cache.', ['db']),
+             lambda db: db.cache_size()),
+        ]
+        for db, name in self._getdbs():
+            for fam, fn in specs:
+                fam.add_metric([name], fn(db))
+        for fam, _ in specs:
+            yield fam
+
+    def _collect_activity(self):
+        conns = _gauge('zodb_connections', 'Open ZODB connections.', ['db'])
+        loads = _counter('zodb_object_loads', 'Total ZODB object loads.', ['db'])
+        stores = _counter('zodb_object_stores', 'Total ZODB object stores.', ['db'])
+
+        for db, name in self._getdbs():
+            zodb = db._getDB()
+            if zodb.getActivityMonitor() is None:
+                zodb.setActivityMonitor(ActivityMonitor())
+            now = time.time()
+            with _ACTIVITY_LOCK:
+                # First scrape backfills 60s rather than asking "since epoch".
+                state = _ACTIVITY.setdefault(
+                    name, {'loads': 0, 'stores': 0, 'last_end': now - 60})
+                data = zodb.getActivityMonitor().getActivityAnalysis(
+                    start=state['last_end'], end=now, divisions=1)[0]
+                state['loads'] += data['loads']
+                state['stores'] += data['stores']
+                state['last_end'] = now
+                loads_total = state['loads']
+                stores_total = state['stores']
+            conns.add_metric([name], data['connections'])
+            loads.add_metric([name], loads_total)
+            stores.add_metric([name], stores_total)
+        yield conns
+        yield loads
+        yield stores
+
+    def _collect_connections(self):
+        active = _gauge('zope_connection_active_objects',
+                        'Active (non-ghost) objects in a ZODB connection cache.',
+                        ['db', 'connection'])
+        total = _gauge('zope_connection_total_objects',
+                       'Total objects in a ZODB connection cache.',
+                       ['db', 'connection'])
+        for db, name in self._getdbs():
+            details = sorted(db._p_jar.db().cacheDetailSize(),
+                             key=lambda m: m['connection'])
+            for i, d in enumerate(details):
+                active.add_metric([name, str(i)], d.get('ngsize', 0))
+                total.add_metric([name, str(i)], d.get('size', 0))
+        yield active
+        yield total
 
 
 class Prometheus(BrowserView):
 
     def __call__(self, *args, **kwargs):
-        result = []
-        if Z_SERVER:
-            result.extend(self.zopethreads())
-        result.extend(self.zopecache())
-        result.extend(self.zodbactivity())
-        result.extend(self.zopeconnections())
-        return ''.join(result)
+        registry = CollectorRegistry(auto_describe=True)
+        registry.register(PROCESS_COLLECTOR)
+        registry.register(PLATFORM_COLLECTOR)
+        registry.register(_ZopeCollector(self.request, self.context))
 
-    def _getdbs(self):
-        filestorage = self.request.get('filestorage')
-        db = self.context.unrestrictedTraverse('/Control_Panel/Database')
-        if filestorage == '*':
-            db = self.context.unrestrictedTraverse('/Control_Panel/Database')
-            for filestorage in db.getDatabaseNames():
-                yield (db[filestorage], '_%s' % filestorage)
-        elif filestorage:
-            if filestorage not in db.getDatabaseNames():
-                raise NotFound
-            yield (db[filestorage], '')
-        else:
-            yield (db['main'], '')
-
-    def zopethreads(self):
-        if sys.version_info < (2, 5):
-            import threadframe
-            thread = threadframe.dict
-        else:
-            thread = sys._current_frames
-        frames = thread()
-        total_threads = len(frames)
-        if ZServer.PubCore._handle is not None:
-            handler_lists = ZServer.PubCore._handle.im_self._lists
-        else:
-            handler_lists = ((), (), ())
-        # Check the ZRendevous __init__ for the definitions below
-        busy_count, request_queue_count, free_count = [
-            len(l) for l in handler_lists
-        ]
-        return [
-            metric(
-                'zope_total_threads', total_threads, 'gauge',
-                'The number of running Zope threads'
-            ),
-            metric(
-                'zope_free_threads', free_count, 'gauge',
-                'The number of Zope threads not in use'
-            ),
-        ]
-
-    def zopecache(self):
-        """ zodb cache statistics """
-        result = []
-        for (db, suffix) in self._getdbs():
-            result.extend(self._zopecache(db, suffix))
-        return result
-
-    def _zopecache(self, db, suffix):
-        return [
-            metric(
-                'zope_total_objects' + suffix, db.database_size(), 'gauge',
-                'The number of objects in the Zope database',
-            ),
-            metric(
-                'zope_cache_memory' + suffix, db.cache_length(), 'gauge',
-                'Memory used by the Zope cache',
-            ),
-            metric(
-                'zope_cache_size' + suffix, db.cache_size(), 'gauge',
-                'The number of objects that can be stored in the Zope cache',
-            ),
-        ]
-
-    def zodbactivity(self):
-        """ zodb activity statistics """
-        result = []
-        for (db, suffix) in self._getdbs():
-            result.extend(self._zodbactivity(db, suffix))
-        return result
-
-    def _zodbactivity(self, db, suffix):
-        now = time()
-        start = now - 15  # Prometheus polls every 15 seconds
-        end = now
-        zodb = db._getDB()
-        if zodb.getActivityMonitor() is None:
-            zodb.setActivityMonitor(ActivityMonitor())
-        data = zodb.getActivityMonitor().getActivityAnalysis(
-            start=start, end=end, divisions=1
-        )[0]
-        return [
-            metric(
-                'zodb_connections' + suffix, data['connections'],
-                'gauge', 'ZODB connections'
-            ),
-            metric(
-                'zodb_load_count' + suffix, data['loads'],
-                'gauge', 'ZODB load count'
-            ),
-            metric(
-                'zodb_store_count' + suffix, data['stores'],
-                'gauge', 'ZODB store count'
-            ),
-        ]
-
-    def _zopeconnections(self, db, suffix):
-        zodb = db._p_jar.db()
-        result = []
-        # try to keep the results in a consistent order
-        sorted_cache_details = sorted(
-            zodb.cacheDetailSize(), key=lambda m: m['connection']
-        )
-        for (conn_id, conn_data) in enumerate(sorted_cache_details):
-            total = conn_data.get('size', 0)
-            active = metric(
-                'zope_connection_active_objects',
-                conn_data.get('ngsize', 0), 'gauge', 'Active Zope Objects',
-                thread=conn_id,
-            )
-            result.append(active)
-            total = metric(
-                'zope_connection_total_objects',
-                conn_data.get('size', 0), 'gauge', 'Total Zope Objects',
-                thread=conn_id,
-            )
-            result.append(total)
-        return result
-
-    def zopeconnections(self):
-        result = []
-        for (db, suffix) in self._getdbs():
-            result.extend(self._zopeconnections(db, suffix))
-        return result
+        encoder, content_type = choose_encoder(
+            self.request.getHeader('Accept', ''))
+        self.request.response.setHeader('Content-Type', content_type)
+        self.request.response.setHeader('Cache-Control', 'no-cache')
+        return encoder(registry)

--- a/src/collective/prometheus/browser.py
+++ b/src/collective/prometheus/browser.py
@@ -19,6 +19,14 @@ try:
 except Exception:
     Z_SERVER = False
 
+try:
+    from Products.CMFCore.utils import getToolByName
+    from Products.CMFPlone import __version__ as PLONE_VERSION
+    PLONE_AVAILABLE = True
+except ImportError:
+    PLONE_AVAILABLE = False
+    PLONE_VERSION = None
+
 logger = logging.getLogger(__name__)
 
 
@@ -156,16 +164,145 @@ class _ZopeCollector(object):
         yield total
 
 
+class _PloneCollector(object):
+    """Per-scrape collector for Plone-domain metrics.
+
+    Only registered when PLONE_AVAILABLE. Sub-collectors are isolated;
+    one failure won't blank a scrape.
+    """
+
+    def __init__(self, request, context):
+        self._request = request
+        self._context = self._resolve_site(context)
+
+    @staticmethod
+    def _resolve_site(context):
+        """Defensive: ensure context has Plone tools.
+
+        With ZCML restricted to IPloneSiteRoot this short-circuits on
+        the first check. Walk one level if a non-site context slips in
+        (e.g. test harness or stray re-registration); fall back to the
+        original context (sub-collectors fail-safe via `_safe`).
+        """
+        if getToolByName(context, 'portal_catalog', None) is not None:
+            return context
+        try:
+            for _id, obj in context.objectItems():
+                if getToolByName(obj, 'portal_catalog', None) is not None:
+                    return obj
+        except Exception:
+            pass
+        return context
+
+    def _safe(self, name, gen):
+        try:
+            yield from gen()
+        except Exception:
+            logger.exception("collector %s failed", name)
+
+    def collect(self):
+        sub_collectors = (
+            ('ploneversion', self._collect_version, True),
+            ('plonecatalog', self._collect_catalog, True),
+            ('plonecontent', self._collect_content, True),
+            ('ploneusers',   self._collect_users,   True),
+        )
+        for name, fn, enabled in sub_collectors:
+            if enabled:
+                yield from self._safe(name, fn)
+
+    def _collect_version(self):
+        g = _gauge(
+            'plone_version_info',
+            'Plone version information (always 1).',
+            ['plone_version', 'cmf_version'],
+        )
+        cmf = ''
+        try:
+            from Products.CMFCore import __version__ as cmf
+        except Exception:
+            cmf = ''
+        g.add_metric([PLONE_VERSION or '', cmf or ''], 1)
+        yield g
+
+    def _collect_catalog(self):
+        catalog = getToolByName(self._context, 'portal_catalog')
+        size = _gauge('plone_catalog_size',
+                      'Number of objects indexed in portal_catalog.')
+        size.add_metric([], len(catalog))
+        yield size
+
+        idx_size = _gauge(
+            'plone_catalog_index_size',
+            'Number of indexed values per portal_catalog index.',
+            ['index'],
+        )
+        for idx_name in catalog.indexes():
+            idx = catalog.Indexes[idx_name]
+            n = getattr(idx, 'numObjects', None)
+            if callable(n):
+                idx_size.add_metric([idx_name], n())
+        yield idx_size
+
+    def _collect_content(self):
+        catalog = getToolByName(self._context, 'portal_catalog')
+        g = _gauge(
+            'plone_content_objects',
+            'Number of catalogued content objects per portal_type.',
+            ['portal_type'],
+        )
+        search = getattr(catalog, 'unrestrictedSearchResults',
+                         catalog.searchResults)
+        for ptype in catalog.uniqueValuesFor('portal_type'):
+            n = len(search(portal_type=ptype))
+            g.add_metric([ptype], n)
+        yield g
+
+    def _collect_users(self):
+        acl = getToolByName(self._context, 'acl_users')
+        users = _gauge('plone_users_total',
+                       'Number of users known to acl_users.')
+        groups = _gauge('plone_groups_total',
+                        'Number of groups known to acl_users.')
+
+        src = getattr(acl, 'source_users', None)
+        if src is not None and hasattr(src, 'getUserIds'):
+            n_users = len(src.getUserIds())
+        else:
+            n_users = len(acl.searchUsers())
+        users.add_metric([], n_users)
+
+        n_groups = 0
+        grp = getattr(acl, 'source_groups', None)
+        if grp is not None and hasattr(grp, 'getGroupIds'):
+            n_groups = len(grp.getGroupIds())
+        groups.add_metric([], n_groups)
+
+        yield users
+        yield groups
+
+
 class Prometheus(BrowserView):
+    """Zope-only metrics. Registered for=*; safe at app root."""
+
+    _include_plone = False
 
     def __call__(self, *args, **kwargs):
         registry = CollectorRegistry(auto_describe=True)
         registry.register(PROCESS_COLLECTOR)
         registry.register(PLATFORM_COLLECTOR)
         registry.register(_ZopeCollector(self.request, self.context))
+        if self._include_plone and PLONE_AVAILABLE:
+            registry.register(_PloneCollector(self.request, self.context))
 
         encoder, content_type = choose_encoder(
             self.request.getHeader('Accept', ''))
         self.request.response.setHeader('Content-Type', content_type)
         self.request.response.setHeader('Cache-Control', 'no-cache')
         return encoder(registry)
+
+
+class PrometheusPlone(Prometheus):
+    """Zope + Plone metrics. Registered for=IPloneSiteRoot."""
+
+    _include_plone = True

--- a/src/collective/prometheus/configure.zcml
+++ b/src/collective/prometheus/configure.zcml
@@ -1,12 +1,25 @@
 <configure
     xmlns="http://namespaces.zope.org/zope"
     xmlns:five="http://namespaces.zope.org/five"
-    xmlns:browser="http://namespaces.zope.org/browser">
+    xmlns:browser="http://namespaces.zope.org/browser"
+    xmlns:zcml="http://namespaces.zope.org/zcml">
 
+    <!-- Zope-only metrics; safe at the app root and in non-Plone Zope. -->
     <browser:page
         for="*"
         name="metrics"
         class=".browser.Prometheus"
         permission="zope2.View"
         />
+
+    <!-- Plone-aware metrics; canonical URL: /<site_id>/@@metrics -->
+    <configure zcml:condition="installed Products.CMFPlone">
+      <browser:page
+          for="Products.CMFPlone.interfaces.IPloneSiteRoot"
+          name="metrics"
+          class=".browser.PrometheusPlone"
+          permission="zope2.View"
+          />
+    </configure>
+
 </configure>


### PR DESCRIPTION
A full rewrite of the `@@metrics` endpoint, modernizing it for current Prometheus practices.

**What changed:**

- **Uses `prometheus_client`** for exposition — proper Content-Type, Cache-Control, and OpenMetrics negotiation. Also mounts the standard `PROCESS_COLLECTOR` / `PLATFORM_COLLECTOR`.
- **ZODB load/store metrics are now real counters** (`zodb_object_loads_total`, `zodb_object_stores_total`), backed by a monotonic accumulator instead of a 15-second sampling window. Resets only on Zope restart — use `rate()` in dashboards.
- **Cleaner labels**: per-database series use a `db` label (not `_<dbname>` name suffixes); per-connection series use a `connection` label (fixes a bug where connection 0 collided with later samples under the old `thread` label).
- **Renames**: `zope_cache_memory` → `zope_cache_objects` (it always counted objects, not bytes).
- **New gauges**: `zope_busy_threads`, `zope_request_queue_length`.
- **Concurrency fix**: collector is built per-request instead of stashing request/context on a process-wide singleton, which raced under concurrent scrapes. Activity totals live in a module-level dict behind a lock.
- **Robustness**: each sub-collector is isolated — one failure no longer blanks the whole scrape.
- **Cleanup**: drops pre-2.5 `threadframe` fallback; tightens `setup.py` classifiers (Plone-only, not raw Zope2).

**Breaking** for anyone with existing dashboards — metric names, labels, and types have changed. Tagged as `2.0.0 (UNRELEASED)`.

**Example output**
```
curl http://localhost:8082/@@metrics
# HELP process_virtual_memory_bytes Virtual memory size in bytes.
# TYPE process_virtual_memory_bytes gauge
process_virtual_memory_bytes 5.33516288e+08
# HELP process_resident_memory_bytes Resident memory size in bytes.
# TYPE process_resident_memory_bytes gauge
process_resident_memory_bytes 2.18329088e+08
# HELP process_start_time_seconds Start time of the process since unix epoch in seconds.
# TYPE process_start_time_seconds gauge
process_start_time_seconds 1.78032678674e+09
# HELP process_cpu_seconds_total Total user and system CPU time spent in seconds.
# TYPE process_cpu_seconds_total counter
process_cpu_seconds_total 12.71
# HELP process_open_fds Number of open file descriptors.
# TYPE process_open_fds gauge
process_open_fds 24.0
# HELP process_max_fds Maximum number of open file descriptors.
# TYPE process_max_fds gauge
process_max_fds 1024.0
# HELP python_info Python platform information
# TYPE python_info gauge
python_info{implementation="CPython",major="3",minor="11",patchlevel="13",version="3.11.13"} 1.0
# HELP zope_total_objects Number of objects in the ZODB.
# TYPE zope_total_objects gauge
zope_total_objects{db="main"} 23393.0
# HELP zope_cache_objects Objects currently held in the ZODB cache.
# TYPE zope_cache_objects gauge
zope_cache_objects{db="main"} 11768.0
# HELP zope_cache_size Configured maximum objects per ZODB cache.
# TYPE zope_cache_size gauge
zope_cache_size{db="main"} 15000.0
# HELP zodb_connections Open ZODB connections.
# TYPE zodb_connections gauge
zodb_connections{db="main"} 0.0
# HELP zodb_object_loads_total Total ZODB object loads.
# TYPE zodb_object_loads_total counter
zodb_object_loads_total{db="main"} 3816.0
# HELP zodb_object_stores_total Total ZODB object stores.
# TYPE zodb_object_stores_total counter
zodb_object_stores_total{db="main"} 7937.0
# HELP zope_connection_active_objects Active (non-ghost) objects in a ZODB connection cache.
# TYPE zope_connection_active_objects gauge
zope_connection_active_objects{connection="0",db="main"} 196.0
zope_connection_active_objects{connection="1",db="main"} 178.0
zope_connection_active_objects{connection="2",db="main"} 182.0
zope_connection_active_objects{connection="3",db="main"} 11187.0
zope_connection_active_objects{connection="4",db="main"} 25.0
# HELP zope_connection_total_objects Total objects in a ZODB connection cache.
# TYPE zope_connection_total_objects gauge
zope_connection_total_objects{connection="0",db="main"} 1296.0
zope_connection_total_objects{connection="1",db="main"} 1238.0
zope_connection_total_objects{connection="2",db="main"} 1238.0
zope_connection_total_objects{connection="3",db="main"} 12496.0
zope_connection_total_objects{connection="4",db="main"} 531.0
```
